### PR TITLE
Add GVL hold time tracking

### DIFF
--- a/test/fallback/test_metrics.rb
+++ b/test/fallback/test_metrics.rb
@@ -7,11 +7,15 @@ module GVLTools
     def global_timer_has_working_interface
       assert_basic_interface(GlobalTimer)
       assert_equal 0, GlobalTimer.monotonic_time
+      assert_equal 0, GlobalTimer.monotonic_wait_time
+      assert_equal 0, GlobalTimer.monotonic_hold_time
     end
 
     def local_timer_has_working_interface
       assert_basic_interface(GlobalTimer)
       assert_equal 0, LocalTimer.monotonic_time
+      assert_equal 0, LocalTimer.monotonic_wait_time
+      assert_equal 0, LocalTimer.monotonic_hold_time
     end
 
     def waiting_threads_has_working_interface

--- a/test/gvl_tools/test_timer.rb
+++ b/test/gvl_tools/test_timer.rb
@@ -15,6 +15,7 @@ module GVLTools
 
     def test_global_timer
       assert_equal 0, GlobalTimer.monotonic_time
+      assert_equal 0, GlobalTimer.monotonic_wait_time
       GlobalTimer.enable
 
       5.times.map do
@@ -28,8 +29,32 @@ module GVLTools
       GlobalTimer.disable
 
       refute_predicate GlobalTimer.monotonic_time, :zero?
+      refute_predicate GlobalTimer.monotonic_wait_time, :zero?
+
       thread_global_time = Thread.new { GlobalTimer.monotonic_time }.join.value
       assert_equal GlobalTimer.monotonic_time, thread_global_time
+
+      thread_global_wait_time = Thread.new { GlobalTimer.monotonic_wait_time }.join.value
+      assert_equal GlobalTimer.monotonic_wait_time, thread_global_wait_time
+    end
+
+    def test_global_hold_timer
+      assert_equal 0, GlobalTimer.monotonic_hold_time
+      GlobalTimer.enable
+
+      5.times.map do
+        Thread.new do
+          10.times do
+            cpu_work
+          end
+        end
+      end.each(&:join)
+
+      GlobalTimer.disable
+
+      refute_predicate GlobalTimer.monotonic_hold_time, :zero?
+      thread_global_hold_time = Thread.new { GlobalTimer.monotonic_hold_time }.join.value
+      assert_equal GlobalTimer.monotonic_hold_time, thread_global_hold_time
     end
 
     def test_local_timer
@@ -39,6 +64,40 @@ module GVLTools
         Thread.new do
           cpu_work
           LocalTimer.monotonic_time
+        end
+      end
+      cpu_work
+      timers = threads.each(&:join).map(&:value)
+
+      timers.each do |timer|
+        refute_predicate timer, :zero?
+      end
+    end
+
+    def test_local_wait_timer
+      LocalTimer.enable
+
+      threads = 5.times.map do
+        Thread.new do
+          cpu_work
+          LocalTimer.monotonic_wait_time
+        end
+      end
+      cpu_work
+      timers = threads.each(&:join).map(&:value)
+
+      timers.each do |timer|
+        refute_predicate timer, :zero?
+      end
+    end
+
+    def test_local_hold_timer
+      LocalTimer.enable
+
+      threads = 5.times.map do
+        Thread.new do
+          cpu_work
+          LocalTimer.monotonic_hold_time
         end
       end
       cpu_work


### PR DESCRIPTION
Attempts to add a gvl hold time value to the Global and Local tracking information.

The Global value is tracking. However, the Local value does not. My current suspicion is that the event for RUBY_INTERNAL_THREAD_EVENT_SUSPENDED is not called in the same thread context as the other callbacks, and thus the wrong thread-local variable is being updated. The global works since it is a shared resource across all threads.