### PR TITLE
Replace rb_atomic_t by C11 atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Use C11 atomics instead of MRI's `rb_atomic_t`.
+
 ## [0.1.0] - 2022-06-14
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   x86_64-linux

--- a/ext/gvltools/extconf.rb
+++ b/ext/gvltools/extconf.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "mkmf"
-if RUBY_ENGINE == "ruby" && have_func("rb_internal_thread_add_event_hook", ["ruby/thread.h"])
+if RUBY_ENGINE == "ruby" &&
+   have_header("stdatomic.h") &&
+   have_func("rb_internal_thread_add_event_hook", ["ruby/thread.h"])
+
   $CFLAGS << " -O3 -Wall "
   create_makefile("gvltools/instrumentation")
 else


### PR DESCRIPTION
Fix: https://github.com/Shopify/gvltools/pull/3

`rb_atomic_t` is `unsigned int` (32bits) so can wrap around too quickly.

This requires more modern compilers but I don't think that is an issue.

FYI: @unflxw