### PR TITLE
Reduce race-conditions when reseting an active WaitingThreads counter

### DIFF
--- a/test/gvl_tools/test_waiting_threads.rb
+++ b/test/gvl_tools/test_waiting_threads.rb
@@ -35,5 +35,24 @@ module GVLTools
 
       assert_equal 0, WaitingThreads.count
     end
+
+    def test_reset_while_active
+      WaitingThreads.enable
+      assert_equal 0, WaitingThreads.count
+
+      count = 4
+      threads = 5.times.map do
+        Thread.new do
+          5.times do
+            cpu_work
+          end
+          count -= 1
+          GVLTools::WaitingThreads.reset if count > 0
+        end
+      end
+      threads.each(&:join)
+
+      assert_equal 0, WaitingThreads.count
+    end
   end
 end


### PR DESCRIPTION
Ref: https://github.com/Shopify/gvltools/issues/7

I wasn't really envisoning `reset` to be called while a counter is active, at least not this one.

`reset` makes sense for monotonically increasing counters, but for this one no so much.

So another solution might be to just only allow reseting when the counter is disabled.

cc @unflxw, can you tell me more about the use case? I'm very tempted to just raise an error.