### PR TITLE
Avoid WaitingThreads desync

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,15 @@ Style/GlobalVars:
   Exclude:
     - ext/**/extconf.rb
 
+Style/EmptyMethod:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Automatically reset the `WaitingThreads` counter when enabling it (#7).
+- Disallow resetting the `WaitingThreads` counter when it is active (#7).
+
 ## [0.2.0] - 2023-03-28
 
 - Use C11 atomics instead of MRI's `rb_atomic_t`.

--- a/lib/gvltools.rb
+++ b/lib/gvltools.rb
@@ -96,7 +96,26 @@ module GVLTools
       end
       alias_method :count, :count
 
+      def enable
+        unless enabled?
+          reset
+        end
+        super
+      end
+
+      def reset
+        if enabled?
+          raise Error, "can't reset WaitingThreads counter while it is active"
+        else
+          _reset
+        end
+      end
+
       private
+
+      def _reset
+      end
+      alias_method :_reset, :_reset # to be redefined from C.
 
       def metric
         WAITING_THREADS

--- a/test/gvl_tools/test_timer.rb
+++ b/test/gvl_tools/test_timer.rb
@@ -18,7 +18,7 @@ module GVLTools
       GlobalTimer.enable
 
       5.times.map do
-        Thread.new do
+        spawn_thread do
           10.times do
             cpu_work
           end
@@ -28,7 +28,7 @@ module GVLTools
       GlobalTimer.disable
 
       refute_predicate GlobalTimer.monotonic_time, :zero?
-      thread_global_time = Thread.new { GlobalTimer.monotonic_time }.join.value
+      thread_global_time = spawn_thread { GlobalTimer.monotonic_time }.join.value
       assert_equal GlobalTimer.monotonic_time, thread_global_time
     end
 
@@ -36,7 +36,7 @@ module GVLTools
       LocalTimer.enable
 
       threads = 5.times.map do
-        Thread.new do
+        spawn_thread do
           cpu_work
           LocalTimer.monotonic_time
         end
@@ -50,7 +50,7 @@ module GVLTools
     end
 
     def test_local_timer_init
-      thread_local_time = Thread.new { LocalTimer.monotonic_time }.join.value
+      thread_local_time = spawn_thread { LocalTimer.monotonic_time }.join.value
       assert_predicate thread_local_time, :zero?
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,24 @@ require "gvltools"
 require "minitest/autorun"
 
 module GVLToolsTestHelper
+  def before_setup
+    @_threads = []
+  end
+
+  def after_teardown
+    @_threads.each do |thread|
+      thread.kill
+      thread.join
+    end
+  end
+
   private
+
+  def spawn_thread(&block)
+    thread = Thread.new(&block)
+    @_threads << thread
+    thread
+  end
 
   def cpu_work
     fibonacci(20)


### PR DESCRIPTION
Fix: #7 

Since this counter isn't monotonic like the others, if you reset it while it's active or if you start/stop it without resting it, you may get bogus values.

cc @unflxw: does that make sense to you?