### PR TITLE
Fix compatibility with Ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['3.1', '3.2', 'head']
+        ruby: ['3.1', '3.2', '3.3', 'head']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fixed compatibility with Ruby 3.3.0.
+
 ## [0.3.0] - 2023-04-11
 
 - Automatically reset the `WaitingThreads` counter when enabling it (#7).

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,10 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in gvltools.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
+gem "rake"
+gem "rake-compiler"
 
 gem "minitest", "~> 5.0"
-
 gem "rubocop", "~> 1.21"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,40 +7,45 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
     minitest (5.15.0)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.24.0)
+    parser (3.3.0.2)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
-    regexp_parser (2.5.0)
-    rexml (3.2.5)
-    rubocop (1.30.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.59.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.18.0, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.18.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.1.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-21
-  arm64-darwin-22
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES
   gvltools!
   minitest (~> 5.0)
-  rake (~> 13.0)
+  rake
   rake-compiler
   rubocop (~> 1.21)
 

--- a/ext/gvltools/extconf.rb
+++ b/ext/gvltools/extconf.rb
@@ -3,9 +3,10 @@
 require "mkmf"
 if RUBY_ENGINE == "ruby" &&
    have_header("stdatomic.h") &&
-   have_func("rb_internal_thread_add_event_hook", ["ruby/thread.h"])
+   have_func("rb_internal_thread_add_event_hook", ["ruby/thread.h"]) # 3.1+
 
   $CFLAGS << " -O3 -Wall "
+  have_func("rb_internal_thread_specific_get", "ruby/thread.h") # 3.3+
   create_makefile("gvltools/instrumentation")
 else
   File.write("Makefile", dummy_makefile($srcdir).join)

--- a/gvltools.gemspec
+++ b/gvltools.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/gvltools/extconf.rb"]
-
-  spec.add_development_dependency "rake-compiler"
 end


### PR DESCRIPTION
There was a number of changes in the GVL instrumentation API in 3.3, most notably events are no longer guaranteed to be triggered from the concerned native thread, so we can no longer rely on C thread local.

Instead we receive the concerned thread as callback argument, and we can use the `rb_internal_thread_specific_*` API to store thread local data.

