### PR TITLE
Mention in doc that we still need to enable gvltools for middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It is particularly useful to detect wether an application use too many threads, 
 For instance as a Rack middleware:
 
 ```ruby
+# lib/gvl_instrumentation_middleware.rb
 class GVLInstrumentationMiddleware
   def initialize(app)
     @app = app
@@ -57,6 +58,10 @@ class GVLInstrumentationMiddleware
     response
   end
 end
+
+# config/application.rb
+GVLTools::LocalTimer.enable
+config.middleware.use GvlInstrumentationMiddleware
 ```
 
 Starting from Ruby 3.3, a thread local timer can be accessed from another thread:


### PR DESCRIPTION
Hello

While looking at doc, even if it's written earlier. I think it's a good idea to put it in code example on rack middleware.

It seems people enable it in `initialize` too https://github.com/vishnu-m/gvlwait/blob/0cdefa904482214ce1828364f6af75f28fc56c93/lib/gvlwait/gvl_instrumentation_middleware.rb#L15C7-L15C34