### PR TITLE
Update README.md - Rails 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ end
 
 # config/application.rb
 GVLTools::LocalTimer.enable
+require "gvl_instrumentation_middleware"
 config.middleware.use GVLInstrumentationMiddleware
 ```
 


### PR DESCRIPTION
gvl_instrumentation_middleware is not autoloaded by default.

I needed to add `require "gvl_instrumentation_middleware"` to make it work with RoR 7.2.1

Please note I am newbie w/ RoR stack, so I may as well be doing something wrong here.